### PR TITLE
IME Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,7 +384,7 @@ endif()
 
 if(TARGET_OS STREQUAL "windows")
   set(PLATFORM_CLIENT)
-  set(PLATFORM_CLIENT_LIBS opengl32 winmm)
+  set(PLATFORM_CLIENT_LIBS opengl32 winmm imm32)
   set(PLATFORM_LIBS ws2_32) # Windows sockets
 elseif(TARGET_OS STREQUAL "mac")
   find_library(CARBON Carbon)

--- a/bam.lua
+++ b/bam.lua
@@ -272,6 +272,7 @@ function GenerateWindowsSettings(settings, conf, target_arch, compiler)
 	settings.link.extrafiles:Add(manifests.client)
 	settings.link.libs:Add("opengl32")
 	settings.link.libs:Add("winmm")
+	settings.link.libs:Add("imm32")
 	BuildClient(settings)
 
 	-- Content

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -94,6 +94,7 @@ void CInput::Init()
 	m_pGraphics = Kernel()->RequestInterface<IEngineGraphics>();
 	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
+	SDL_StopTextInput();
 
 	MouseModeRelative();
 
@@ -344,6 +345,25 @@ bool CInput::KeyState(int Key) const
 	return m_aInputState[Key>=KEY_MOUSE_1 ? Key : SDL_GetScancodeFromKey(KeyToKeycode(Key))];
 }
 
+void CInput::SetTextCompositionWindowPosition(float X, float Y)
+{
+	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
+	int ScreenWidth = Graphics()->ScreenWidth();
+	int ScreenHeight = Graphics()->ScreenHeight();
+	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+
+	vec2 ScreenScale = vec2(ScreenWidth / (ScreenX1 - ScreenX0), ScreenHeight / (ScreenY1 - ScreenY0));
+
+	SDL_Rect Rect;
+	Rect.x = X * ScreenScale.x;
+	Rect.y = Y * ScreenScale.y;
+	Rect.h = ScreenHeight / 2;		// unused by SDL2
+	Rect.w = ScreenWidth;			// unused by SDL2
+
+	// TODO: use window coordinate instead of canvas coordinate (requires #2827)
+	SDL_SetTextInputRect(&Rect);
+}
+
 int CInput::Update()
 {
 	// keep the counter between 1..0xFFFF, 0 means not pressed
@@ -552,7 +572,10 @@ int CInput::Update()
 	}
 
 	if(m_CompositionCursor == 0 || isCompositionBreaking)
+	{
 		m_CompositionCursor = COMP_CURSOR_INACTIVE;
+		AddEvent(0, 0, IInput::FLAG_TEXT);
+	}
 
 	return 0;
 }

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -25,6 +25,14 @@
 	#define SDL_JOYSTICK_AXIS_MAX 32767
 #endif
 
+// for platform specific features that aren't available or is broken in SDL
+#include "SDL_syswm.h"
+
+#if defined(CONF_FAMILY_WINDOWS)
+#include <windows.h>
+#include <imm.h>
+#endif
+
 void CInput::AddEvent(char *pText, int Key, int Flags)
 {
 	if(m_NumEvents != INPUT_BUFFER_SIZE)
@@ -61,6 +69,11 @@ CInput::CInput()
 	m_MouseDoubleClick = false;
 
 	m_NumEvents = 0;
+	
+	m_CompositionCursor = COMP_CURSOR_INACTIVE;
+	m_CompositionSelectedLength = 0;
+	m_CandidateCount = 0;
+	m_CandidateSelectedIndex = -1;
 }
 
 CInput::~CInput()
@@ -74,10 +87,12 @@ CInput::~CInput()
 
 void CInput::Init()
 {
+	// enable system messages
+	SDL_EventState(SDL_SYSWMEVENT, SDL_ENABLE);
+
 	m_pGraphics = Kernel()->RequestInterface<IEngineGraphics>();
 	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
-	// FIXME: unicode handling: use SDL_StartTextInput/SDL_StopTextInput on inputs
 
 	MouseModeRelative();
 
@@ -351,9 +366,42 @@ int CInput::Update()
 			int Key = -1;
 			int Scancode = 0;
 			int Action = IInput::FLAG_PRESS;
-			switch (Event.type)
+			switch(Event.type)
 			{
+				// handle text editing candidate
+				case SDL_SYSWMEVENT:
+					ProcessSystemMessage(Event.syswm.msg);
+					break;
+
+				// handle on the spot text editing
+				case SDL_TEXTEDITING:
+				{
+					const int CompositionLength = str_length(Event.edit.text);
+					if(CompositionLength)
+					{
+						str_copy(m_aComposition, Event.edit.text, sizeof(m_aComposition));
+						m_CompositionCursor = 0;
+						for(int i = 0; i < Event.edit.start; i++)
+							m_CompositionCursor = str_utf8_forward(m_aComposition, m_CompositionCursor);
+						m_CompositionSelectedLength = Event.edit.length;
+					}
+					else
+					{
+						m_aComposition[0] = '\0';
+						m_CompositionCursor = 0;
+						m_CompositionSelectedLength = 0;
+
+						// close candidate window as well
+						m_CandidateCount = 0;
+						m_CandidateSelectedIndex = -1;
+					}
+					break;
+				}
 				case SDL_TEXTINPUT:
+					m_aComposition[0] = 0;
+					m_CandidateCount = 0;
+					m_CandidateSelectedIndex = -1;
+					m_CompositionCursor = COMP_CURSOR_INACTIVE;
 					AddEvent(Event.text.text, 0, IInput::FLAG_TEXT);
 					break;
 
@@ -475,8 +523,7 @@ int CInput::Update()
 					return 1;
 			}
 
-			//
-			if(Key != -1)
+			if(Key != -1 && m_CompositionCursor == COMP_CURSOR_INACTIVE)
 			{
 				if(Action&IInput::FLAG_PRESS)
 				{
@@ -485,12 +532,69 @@ int CInput::Update()
 				}
 				AddEvent(0, Key, Action);
 			}
-
 		}
 	}
+
+	if(m_CompositionCursor == 0)
+		m_CompositionCursor = COMP_CURSOR_INACTIVE;
 
 	return 0;
 }
 
+void CInput::ProcessSystemMessage(SDL_SysWMmsg *pMsg)
+{
+#if defined(CONF_FAMILY_WINDOWS)
+	// Todo SDL: remove this after SDL2 supports IME candidates
+	if(pMsg->subsystem == SDL_SYSWM_WINDOWS)
+	{
+		if(pMsg->msg.win.msg != WM_IME_NOTIFY)
+			return;
+
+		switch(pMsg->msg.win.wParam)
+		{
+			case IMN_OPENCANDIDATE:
+			case IMN_CHANGECANDIDATE:
+			{
+				HWND WindowHandle = pMsg->msg.win.hwnd;
+				DWORD CandidateCount;
+				HIMC ImeContext = ImmGetContext(WindowHandle);
+				DWORD Size = ImmGetCandidateListCountW(ImeContext, &CandidateCount);
+				LPCANDIDATELIST CandidateList = NULL;
+				if(Size > 0)
+				{
+					CandidateList = (LPCANDIDATELIST)mem_alloc(Size, 1);
+					Size = ImmGetCandidateListW(ImeContext, 0, CandidateList, Size);
+				}
+				if(CandidateList && Size > 0)
+				{
+					m_CandidateCount = 0;
+					for (DWORD i = CandidateList->dwPageStart; i < CandidateList->dwCount && m_CandidateCount < (int)CandidateList->dwPageSize; i++)
+					{
+						LPCWSTR Candidate = (LPCWSTR)((DWORD_PTR)CandidateList + CandidateList->dwOffset[i]);
+						WideCharToMultiByte(CP_UTF8, 0, Candidate, -1, m_aaCandidates[m_CandidateCount], MAX_CANDIDATE_ARRAY_SIZE, "?", NULL);
+						m_aaCandidates[m_CandidateCount][MAX_CANDIDATE_ARRAY_SIZE-1] = '\0';
+						m_CandidateCount++;
+					}
+					m_CandidateSelectedIndex = CandidateList->dwSelection;
+				}
+				else
+				{
+					m_CandidateCount = 0;
+					m_CandidateSelectedIndex = -1;
+				}
+
+				if(CandidateList)
+					mem_free(CandidateList);
+				ImmReleaseContext(WindowHandle, ImeContext);
+				break;	
+			}
+			case IMN_CLOSECANDIDATE:
+				m_CandidateCount = 0;
+				m_CandidateSelectedIndex = -1;
+				break;
+		}
+	}
+#endif
+}
 
 IEngineInput *CreateEngineInput() { return new CInput; }

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -87,6 +87,6 @@ public:
 	const char *GetCandidate(int Index) { return m_aaCandidates[Index]; }
 	int GetCandidateCount() { return m_CandidateCount; }
 	int GetCandidateSelectedIndex() { return m_CandidateSelectedIndex; }
-	void SetCompositionWindowPosition(float X, float Y);
+	void SetCompositionWindowPosition(float X, float Y, float H);
 };
 #endif

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -85,6 +85,6 @@ public:
 	const char *GetCandidate(int Index) { return m_aaCandidates[Index]; }
 	int GetCandidateCount() { return m_CandidateCount; }
 	int GetCandidateSelectedIndex() { return m_CandidateSelectedIndex; }
+	void SetTextCompositionWindowPosition(float X, float Y);
 };
-
 #endif

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -76,7 +76,10 @@ public:
 	const char *GetClipboardText();
 	void SetClipboardText(const char *pText);
 
+	void StartTextInput();
+	void StopTextInput();
 	const char *GetComposition() { return m_aComposition; }
+	bool HasComposition() { return m_CompositionCursor != COMP_CURSOR_INACTIVE; }
 	int GetCompositionCursor() { return m_CompositionCursor; }
 	int GetCompositionSelectedLength() { return m_CompositionSelectedLength; }
 	const char *GetCandidate(int Index) { return m_aaCandidates[Index]; }

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -25,6 +25,14 @@ class CInput : public IEngineInput
 
 	bool m_MouseDoubleClick;
 
+	// ime support
+	char m_aComposition[MAX_COMPOSITION_ARRAY_SIZE];
+	int m_CompositionCursor;
+	int m_CompositionSelectedLength;
+	char m_aaCandidates[MAX_CANDIDATES][MAX_CANDIDATE_ARRAY_SIZE];
+	int m_CandidateCount;
+	int m_CandidateSelectedIndex;
+
 	void AddEvent(char *pText, int Key, int Flags);
 	void Clear();
 	bool IsEventValid(CEvent *pEvent) const { return pEvent->m_InputCount == m_InputCounter; };
@@ -36,6 +44,8 @@ class CInput : public IEngineInput
 
 	void ClearKeyStates();
 	bool KeyState(int Key) const;
+
+	void ProcessSystemMessage(SDL_SysWMmsg *pMsg);
 
 	IEngineGraphics *Graphics() { return m_pGraphics; }
 
@@ -65,6 +75,13 @@ public:
 
 	const char *GetClipboardText();
 	void SetClipboardText(const char *pText);
+
+	const char *GetComposition() { return m_aComposition; }
+	int GetCompositionCursor() { return m_CompositionCursor; }
+	int GetCompositionSelectedLength() { return m_CompositionSelectedLength; }
+	const char *GetCandidate(int Index) { return m_aaCandidates[Index]; }
+	int GetCandidateCount() { return m_CandidateCount; }
+	int GetCandidateSelectedIndex() { return m_CandidateSelectedIndex; }
 };
 
 #endif

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -29,6 +29,7 @@ class CInput : public IEngineInput
 	char m_aComposition[MAX_COMPOSITION_ARRAY_SIZE];
 	int m_CompositionCursor;
 	int m_CompositionSelectedLength;
+	int m_CompositionLength;
 	char m_aaCandidates[MAX_CANDIDATES][MAX_CANDIDATE_ARRAY_SIZE];
 	int m_CandidateCount;
 	int m_CandidateSelectedIndex;
@@ -79,12 +80,13 @@ public:
 	void StartTextInput();
 	void StopTextInput();
 	const char *GetComposition() { return m_aComposition; }
-	bool HasComposition() { return m_CompositionCursor != COMP_CURSOR_INACTIVE; }
+	bool HasComposition() { return m_CompositionLength != COMP_LENGTH_INACTIVE; }
 	int GetCompositionCursor() { return m_CompositionCursor; }
 	int GetCompositionSelectedLength() { return m_CompositionSelectedLength; }
+	int GetCompositionLength() { return m_CompositionLength; }
 	const char *GetCandidate(int Index) { return m_aaCandidates[Index]; }
 	int GetCandidateCount() { return m_CandidateCount; }
 	int GetCandidateSelectedIndex() { return m_CandidateSelectedIndex; }
-	void SetTextCompositionWindowPosition(float X, float Y);
+	void SetCompositionWindowPosition(float X, float Y);
 };
 #endif

--- a/src/engine/client/textrender.cpp
+++ b/src/engine/client/textrender.cpp
@@ -1266,7 +1266,7 @@ int CTextRender::CharToGlyph(CTextCursor *pCursor, int NumChars, float *pLineWid
 	{
 		int Line = pCursor->m_Glyphs[LastGlyphIndex].m_Line;
 		
-		for (LastGlyphIndex = LastGlyphIndex; LastGlyphIndex < NumGlyphs; ++LastGlyphIndex)
+		for (; LastGlyphIndex < NumGlyphs; ++LastGlyphIndex)
 		{
 			if(LastGlyphIndex + 1 >= NumGlyphs)
 				break;

--- a/src/engine/client/textrender.cpp
+++ b/src/engine/client/textrender.cpp
@@ -1232,20 +1232,34 @@ void CTextRender::DrawTextShadowed(CTextCursor *pCursor, vec2 ShadowOffset, floa
 	DrawText(pCursor, vec2(0, 0), 0, false, Alpha, StartGlyph, NumGlyphs);
 }
 
-vec2 CTextRender::CaretPosition(CTextCursor *pCursor, int NumChars)
+int CTextRender::CharToGlyph(CTextCursor *pCursor, int NumChars)
 {
 	int CursorChars = 0;
 	int NumGlyphs = pCursor->m_Glyphs.size();
 	if(NumGlyphs == 0 || NumChars == 0)
-		return pCursor->m_CursorPos;
+		return 0;
 
 	for(int i = 0; i < NumGlyphs; ++i)
 	{
 		CursorChars += pCursor->m_Glyphs[i].m_NumChars;
 		if(CursorChars > NumChars)
-			return pCursor->m_CursorPos + pCursor->m_Glyphs[i].m_Advance;
+			return i;
 	}
 
+	return NumGlyphs;
+}
+
+vec2 CTextRender::CaretPosition(CTextCursor *pCursor, int NumChars)
+{
+	int CursorChars = 0;
+	int NumGlyphs = pCursor->m_Glyphs.size();
+	int GlyphIndex = CharToGlyph(pCursor, NumChars);
+	if(GlyphIndex == 0 || NumGlyphs == 0)
+		return pCursor->m_CursorPos;
+
+	if(GlyphIndex < NumGlyphs)
+		return pCursor->m_CursorPos + pCursor->m_Glyphs[GlyphIndex].m_Advance;
+	
 	CScaledGlyph *pLastScaled = &pCursor->m_Glyphs[NumGlyphs-1];
 	return pCursor->m_CursorPos + pLastScaled->m_Advance + vec2(pLastScaled->m_pGlyph->m_AdvanceX, 0) * pLastScaled->m_Size;
 }

--- a/src/engine/client/textrender.cpp
+++ b/src/engine/client/textrender.cpp
@@ -601,7 +601,7 @@ CWordWidthHint CTextRender::MakeWord(CTextCursor *pCursor, const char *pText, co
 		bool CanBreak = !IsSpace && (BreakWord || pCursor->m_StartOfLine);
 		if(Hint.m_EffectiveAdvanceX - WordStartAdvanceX > MaxWidth || (CanBreak && pCursor->m_Advance.x + AdvanceX > MaxWidth))
 		{
-			Hint.m_CharCount--;
+			Hint.m_CharCount -= NumChars;
 			Hint.m_IsBroken = true;
 			break;
 		}
@@ -1232,36 +1232,108 @@ void CTextRender::DrawTextShadowed(CTextCursor *pCursor, vec2 ShadowOffset, floa
 	DrawText(pCursor, vec2(0, 0), 0, false, Alpha, StartGlyph, NumGlyphs);
 }
 
-int CTextRender::CharToGlyph(CTextCursor *pCursor, int NumChars)
+int CTextRender::CharToGlyph(CTextCursor *pCursor, int NumChars, float *pLineWidth)
 {
 	int CursorChars = 0;
 	int NumGlyphs = pCursor->m_Glyphs.size();
 	if(NumGlyphs == 0 || NumChars == 0)
+	{
+		if (pLineWidth)
+			*pLineWidth = 0.0f;
 		return 0;
+	}
 
+	int GlyphIndex = -1;
 	for(int i = 0; i < NumGlyphs; ++i)
 	{
 		CursorChars += pCursor->m_Glyphs[i].m_NumChars;
 		if(CursorChars > NumChars)
-			return i;
+		{
+			GlyphIndex = i;
+			break;
+		}
 	}
 
-	return NumGlyphs;
+	int LastGlyphIndex = GlyphIndex;
+
+	if (GlyphIndex < 0)
+	{
+		GlyphIndex = NumGlyphs;
+		LastGlyphIndex = GlyphIndex - 1;
+	}
+
+	if (pLineWidth)
+	{
+		int Line = pCursor->m_Glyphs[LastGlyphIndex].m_Line;
+		
+		for (LastGlyphIndex = LastGlyphIndex; LastGlyphIndex < NumGlyphs; ++LastGlyphIndex)
+		{
+			if(LastGlyphIndex + 1 >= NumGlyphs)
+				break;
+			
+			if(pCursor->m_Glyphs[LastGlyphIndex].m_Line > Line)
+			{
+				LastGlyphIndex -= 1;
+				break;
+			}
+		}
+
+		const CScaledGlyph& rScaled = pCursor->m_Glyphs[LastGlyphIndex];
+		const CGlyph *pGlyph = rScaled.m_pGlyph;
+		*pLineWidth = rScaled.m_Advance.x + pGlyph->m_AdvanceX * rScaled.m_Size;
+	}
+	
+	return GlyphIndex;
 }
 
 vec2 CTextRender::CaretPosition(CTextCursor *pCursor, int NumChars)
 {
+	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
+	int ScreenWidth = Graphics()->ScreenWidth();
+	int ScreenHeight = Graphics()->ScreenHeight();
+	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+
+	vec2 ScreenScale = vec2(ScreenWidth/(ScreenX1-ScreenX0), ScreenHeight/(ScreenY1-ScreenY0));
+	float Size = pCursor->m_FontSize;
+	int PixelSize = (int)(Size * ScreenScale.y);
+	Size = PixelSize / ScreenScale.y;
+
 	int CursorChars = 0;
 	int NumGlyphs = pCursor->m_Glyphs.size();
-	int GlyphIndex = CharToGlyph(pCursor, NumChars);
+	float LineWidth;
+	int GlyphIndex = CharToGlyph(pCursor, NumChars, &LineWidth);
+
+	int HorizontalAlign = pCursor->m_Align & TEXTALIGN_MASK_HORI;
+	int VerticalAlign = pCursor->m_Align & TEXTALIGN_MASK_VERT;
+
+	vec2 Offset = vec2(0,0);
+	float LineOffset = 0.0f;
+
+	if(HorizontalAlign == TEXTALIGN_RIGHT)
+	{
+		Offset.x = -pCursor->m_Width;
+		LineOffset = pCursor->m_Width - LineWidth;
+	}
+	else if(HorizontalAlign == TEXTALIGN_CENTER)
+	{
+		Offset.x = -pCursor->m_Width / 2.0f;
+		LineOffset = (pCursor->m_Width - LineWidth) / 2.0f;
+	}
+	
+	if(VerticalAlign == TEXTALIGN_BOTTOM)
+		Offset.y = -pCursor->m_Height + Size * 1.35f;
+	else if(VerticalAlign == TEXTALIGN_MIDDLE)
+		Offset.y = -pCursor->m_Height / 2.0f + Size * 0.675f;
+
 	if(GlyphIndex == 0 || NumGlyphs == 0)
-		return pCursor->m_CursorPos;
+		return pCursor->m_CursorPos + Offset;
 
 	if(GlyphIndex < NumGlyphs)
-		return pCursor->m_CursorPos + pCursor->m_Glyphs[GlyphIndex].m_Advance;
+		return pCursor->m_CursorPos + pCursor->m_Glyphs[GlyphIndex].m_Advance + Offset;
 	
 	CScaledGlyph *pLastScaled = &pCursor->m_Glyphs[NumGlyphs-1];
-	return pCursor->m_CursorPos + pLastScaled->m_Advance + vec2(pLastScaled->m_pGlyph->m_AdvanceX, 0) * pLastScaled->m_Size;
+	return pCursor->m_CursorPos + pLastScaled->m_Advance + Offset
+		+ vec2(pLastScaled->m_pGlyph->m_AdvanceX + LineOffset, 0) * pLastScaled->m_Size;
 }
 
 IEngineTextRender *CreateEngineTextRender() { return new CTextRender; }

--- a/src/engine/client/textrender.cpp
+++ b/src/engine/client/textrender.cpp
@@ -1256,13 +1256,13 @@ int CTextRender::CharToGlyph(CTextCursor *pCursor, int NumChars, float *pLineWid
 
 	int LastGlyphIndex = GlyphIndex;
 
-	if (GlyphIndex < 0)
+	if(GlyphIndex < 0)
 	{
 		GlyphIndex = NumGlyphs;
 		LastGlyphIndex = GlyphIndex - 1;
 	}
 
-	if (pLineWidth)
+	if(pLineWidth)
 	{
 		int Line = pCursor->m_Glyphs[LastGlyphIndex].m_Line;
 		
@@ -1298,7 +1298,6 @@ vec2 CTextRender::CaretPosition(CTextCursor *pCursor, int NumChars)
 	int PixelSize = (int)(Size * ScreenScale.y);
 	Size = PixelSize / ScreenScale.y;
 
-	int CursorChars = 0;
 	int NumGlyphs = pCursor->m_Glyphs.size();
 	float LineWidth;
 	int GlyphIndex = CharToGlyph(pCursor, NumChars, &LineWidth);

--- a/src/engine/client/textrender.h
+++ b/src/engine/client/textrender.h
@@ -214,6 +214,7 @@ public:
 	void DrawTextOutlined(CTextCursor *pCursor, float Alpha, int StartGlyph, int NumGlyphs);
 	void DrawTextShadowed(CTextCursor *pCursor, vec2 ShadowOffset, float Alpha, int StartGlyph, int NumGlyphs);
 
+	int CharToGlyph(CTextCursor *pCursor, int NumChars);
 	vec2 CaretPosition(CTextCursor *pCursor, int NumChars);
 };
 

--- a/src/engine/client/textrender.h
+++ b/src/engine/client/textrender.h
@@ -214,7 +214,7 @@ public:
 	void DrawTextOutlined(CTextCursor *pCursor, float Alpha, int StartGlyph, int NumGlyphs);
 	void DrawTextShadowed(CTextCursor *pCursor, vec2 ShadowOffset, float Alpha, int StartGlyph, int NumGlyphs);
 
-	int CharToGlyph(CTextCursor *pCursor, int NumChars);
+	int CharToGlyph(CTextCursor *pCursor, int NumChars, float *pLineWidth = 0);
 	vec2 CaretPosition(CTextCursor *pCursor, int NumChars);
 };
 

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -18,7 +18,7 @@ public:
 	public:
 		int m_Flags;
 		int m_Key;
-		char m_aText[32];
+		char m_aText[32*UTF8_BYTE_LENGTH+1];
 		int m_InputCount;
 	};
 
@@ -39,6 +39,7 @@ public:
 		FLAG_RELEASE=2,
 		FLAG_REPEAT=4,
 		FLAG_TEXT=8,
+		FLAG_TEXTEDIT=16,
 
 		CURSOR_NONE = 0,
 		CURSOR_MOUSE,
@@ -93,7 +94,10 @@ public:
 	virtual void SetClipboardText(const char *pText) = 0;
 
 	// text editing
-	virtual const char *GetComposition() = 0;
+	virtual void StartTextInput() = 0;
+	virtual void StopTextInput() = 0;
+ 	virtual const char *GetComposition() = 0;
+	virtual bool HasComposition() = 0;
 	virtual int GetCompositionCursor() = 0;
 	virtual int GetCompositionSelectedLength() = 0;
 	virtual const char *GetCandidate(int Index) = 0;

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -48,10 +48,9 @@ public:
 		MAX_CANDIDATES = 16,
 		MAX_CANDIDATE_LENGTH = 16,
 		MAX_CANDIDATE_ARRAY_SIZE=MAX_CANDIDATE_LENGTH*UTF8_BYTE_LENGTH+1,
-		MAX_COMPOSITION_LENGTH = 64,
-		MAX_COMPOSITION_ARRAY_SIZE = MAX_COMPOSITION_LENGTH*UTF8_BYTE_LENGTH+1,
+		MAX_COMPOSITION_ARRAY_SIZE = 32, // SDL2 limitation
 
-		COMP_CURSOR_INACTIVE = -1
+		COMP_LENGTH_INACTIVE = -1
 	};
 
 	// events
@@ -100,10 +99,11 @@ public:
 	virtual bool HasComposition() = 0;
 	virtual int GetCompositionCursor() = 0;
 	virtual int GetCompositionSelectedLength() = 0;
+	virtual int GetCompositionLength() = 0;
 	virtual const char *GetCandidate(int Index) = 0;
 	virtual int GetCandidateCount() = 0;
 	virtual int GetCandidateSelectedIndex() = 0;
-	virtual void SetTextCompositionWindowPosition(float X, float Y) = 0;
+	virtual void SetCompositionWindowPosition(float X, float Y) = 0;
 
 	int CursorRelative(float *pX, float *pY)
 	{

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -42,7 +42,15 @@ public:
 
 		CURSOR_NONE = 0,
 		CURSOR_MOUSE,
-		CURSOR_JOYSTICK
+		CURSOR_JOYSTICK,
+
+		MAX_CANDIDATES = 16,
+		MAX_CANDIDATE_LENGTH = 16,
+		MAX_CANDIDATE_ARRAY_SIZE=MAX_CANDIDATE_LENGTH*UTF8_BYTE_LENGTH+1,
+		MAX_COMPOSITION_LENGTH = 64,
+		MAX_COMPOSITION_ARRAY_SIZE = MAX_COMPOSITION_LENGTH*UTF8_BYTE_LENGTH+1,
+
+		COMP_CURSOR_INACTIVE = -1
 	};
 
 	// events
@@ -83,6 +91,14 @@ public:
 	// clipboard
 	virtual const char* GetClipboardText() = 0;
 	virtual void SetClipboardText(const char *pText) = 0;
+
+	// text editing
+	virtual const char *GetComposition() = 0;
+	virtual int GetCompositionCursor() = 0;
+	virtual int GetCompositionSelectedLength() = 0;
+	virtual const char *GetCandidate(int Index) = 0;
+	virtual int GetCandidateCount() = 0;
+	virtual int GetCandidateSelectedIndex() = 0;
 
 	int CursorRelative(float *pX, float *pY)
 	{

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -103,6 +103,7 @@ public:
 	virtual const char *GetCandidate(int Index) = 0;
 	virtual int GetCandidateCount() = 0;
 	virtual int GetCandidateSelectedIndex() = 0;
+	virtual void SetTextCompositionWindowPosition(float X, float Y) = 0;
 
 	int CursorRelative(float *pX, float *pY)
 	{

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -103,7 +103,7 @@ public:
 	virtual const char *GetCandidate(int Index) = 0;
 	virtual int GetCandidateCount() = 0;
 	virtual int GetCandidateSelectedIndex() = 0;
-	virtual void SetCompositionWindowPosition(float X, float Y) = 0;
+	virtual void SetCompositionWindowPosition(float X, float Y, float H) = 0;
 
 	int CursorRelative(float *pX, float *pY)
 	{

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -138,6 +138,7 @@ public:
 		if (StringVersion < 0 || m_StringVersion != StringVersion)
 		{
 			m_Width = 0;
+			m_Height = 0;
 			m_NextLineAdvanceY = 0;
 			m_Advance = vec2(0, 0);
 			m_LineCount = 1;

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -215,6 +215,7 @@ public:
 	virtual void DrawTextShadowed(CTextCursor *pCursor, vec2 ShadowOffset, float Alpha = 1.0f, int StartGlyph = 0, int NumGlyphs = -1) = 0;
 
 	// QoL APIs
+	virtual int CharToGlyph(CTextCursor *pCursor, int NumChars) = 0;
 	virtual vec2 CaretPosition(CTextCursor *pCursor, int NumChars) = 0;
 };
 

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -215,7 +215,7 @@ public:
 	virtual void DrawTextShadowed(CTextCursor *pCursor, vec2 ShadowOffset, float Alpha = 1.0f, int StartGlyph = 0, int NumGlyphs = -1) = 0;
 
 	// QoL APIs
-	virtual int CharToGlyph(CTextCursor *pCursor, int NumChars) = 0;
+	virtual int CharToGlyph(CTextCursor *pCursor, int NumChars, float *pLineWidth = 0) = 0;
 	virtual vec2 CaretPosition(CTextCursor *pCursor, int NumChars) = 0;
 };
 

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -871,25 +871,27 @@ void CChat::OnRender()
 		s_CategoryCursor.MoveTo(x + IconOffsetX + ClientIDWidth, y);
 		TextRender()->DrawTextOutlined(&s_CategoryCursor);
 
-		static CTextCursor m_InputCursor(InputFontSize);
 		vec2 CursorPosition = s_CategoryCursor.CursorPosition();
 		CursorPosition.x += s_CategoryCursor.Width() + 4.0f;
 		CursorPosition.y -= (InputFontSize-CategoryFontSize)*0.5f;
-		m_InputCursor.m_MaxWidth = Width-190.0f-s_CategoryCursor.Width();
-		m_InputCursor.Reset();
+
+		// cache buffered text and only reset when switching modes
+		static CTextCursor m_BufferedCursor(InputFontSize);
+		m_BufferedCursor.Reset(m_Mode);
 
 		//render buffered text
 		if(m_Mode == CHAT_NONE)
 		{
+			m_BufferedCursor.MoveTo(CursorPosition);
+
 			//calculate WidthLimit
-			m_InputCursor.MoveTo(CursorPosition);
-			m_InputCursor.m_MaxWidth = LineWidth+x+3.0f-s_CategoryCursor.Width();
-			m_InputCursor.m_MaxLines = 1;
-			m_InputCursor.m_Flags = TEXTFLAG_ELLIPSIS;
+			m_BufferedCursor.m_MaxWidth = LineWidth+x+3.0f-s_CategoryCursor.Width();
+			m_BufferedCursor.m_MaxLines = 1;
+			m_BufferedCursor.m_Flags = TEXTFLAG_ELLIPSIS;
 
 			//add dots when string excesses length
 			TextRender()->TextColor(1.0f, 1.0f, 1.0f, Blend);
-			TextRender()->TextOutlined(&m_InputCursor, m_Input.GetString(), -1);
+			TextRender()->TextOutlined(&m_BufferedCursor, m_Input.GetString(), -1);
 
 			//render helper annotation
 			static CTextCursor s_InfoCursor(CategoryFontSize*0.75f);
@@ -913,22 +915,37 @@ void CChat::OnRender()
 		}
 		else
 		{
-			float ScrollOffset = m_Input.GetScrollOffset();
-			m_InputCursor.MoveTo(CursorPosition.x, CursorPosition.y - ScrollOffset);
-			m_InputCursor.m_MaxLines = -1;
-			m_InputCursor.m_Flags = TEXTFLAG_WORD_WRAP;
+			CTextCursor *pCursor = m_Input.GetCursor();
+			pCursor->m_FontSize = InputFontSize;
+			pCursor->m_MaxWidth = Width-190.0f-s_CategoryCursor.Width();
 
-			// Render normal text
-			TextRender()->TextDeferred(&m_InputCursor, m_Input.GetString(), -1);
+			float ScrollOffset = m_Input.GetScrollOffset();
+			pCursor->MoveTo(CursorPosition.x, CursorPosition.y - ScrollOffset);
+			pCursor->m_MaxLines = -1;
+			pCursor->m_Flags = TEXTFLAG_WORD_WRAP;
 
 			//Render command autocomplete option hint
-			if(IsTypingCommand() && m_CommandManager.CommandCount() - m_FilteredCount && m_SelectedCommand >= 0)
+			if(IsTypingCommand() && m_CommandManager.CommandCount() - m_FilteredCount && m_SelectedCommand >= 0 && pCursor->LineCount() == 1)
 			{
+				static CTextCursor m_HintCursor(InputFontSize);
+
+				m_HintCursor.Reset();
+				m_HintCursor.MoveTo(pCursor->CursorPosition());
+				m_HintCursor.m_MaxWidth = Width-190.0f-s_CategoryCursor.Width();
+				m_HintCursor.m_MaxLines = 1;
+				m_HintCursor.m_Flags = TEXTFLAG_ELLIPSIS;
+
 				const CCommandManager::CCommand *pCommand = m_CommandManager.GetCommand(m_SelectedCommand);
-				if(str_length(pCommand->m_aName)+1 > str_length(m_Input.GetString()))
+				int InputLength = str_length(m_Input.GetString());
+				if(str_length(pCommand->m_aName)+1 > InputLength)
 				{
-					TextRender()->TextColor(1.0f, 1.0f, 1.0f, 0.5f);
-					TextRender()->TextDeferred(&m_InputCursor, pCommand->m_aName + str_length(m_Input.GetString())-1, -1);
+					// fake render input text again (for correct kerning)
+					TextRender()->TextDeferred(&m_HintCursor, m_Input.GetString(), InputLength);
+					int SkipGlyphs = m_HintCursor.GlyphCount();
+
+					// render actual completion text
+					TextRender()->TextDeferred(&m_HintCursor, pCommand->m_aName+InputLength-1, -1);
+					TextRender()->DrawTextOutlined(&m_HintCursor, 0.5f, SkipGlyphs);
 				}
 			}
 
@@ -944,15 +961,16 @@ void CChat::OnRender()
 			}
 
 			const float Spacing = 1.0f;
-			const CUIRect ClippingRect = { CursorPosition.x-Spacing, CursorPosition.y-Spacing, m_InputCursor.m_MaxWidth+2*Spacing, 2*InputFontSize+3*Spacing };
+			const CUIRect ClippingRect = { CursorPosition.x-Spacing, CursorPosition.y-Spacing, pCursor->m_MaxWidth+2*Spacing, 2*InputFontSize+3*Spacing };
 			const float XScale = Graphics()->ScreenWidth()/Width;
 			const float YScale = Graphics()->ScreenHeight()/Height;
 			Graphics()->ClipEnable((int)(ClippingRect.x*XScale), (int)(ClippingRect.y*YScale), (int)(ClippingRect.w*XScale), (int)(ClippingRect.h*YScale));
-			m_Input.Render(&m_InputCursor);
+			m_Input.Render();
 			Graphics()->ClipDisable();
 
 			// scroll to keep the caret inside the clipping rect
-			float CaretPositionY = TextRender()->CaretPosition(&m_InputCursor, m_Input.GetCursorOffset()).y+InputFontSize/2.0f;
+			// TODO: get caret position from lineinput instead of calculating
+			float CaretPositionY = TextRender()->CaretPosition(pCursor, m_Input.GetCursorOffset()).y+InputFontSize/2.0f;
 			if(CaretPositionY < ClippingRect.y)
 				m_Input.SetScrollOffset(max(0.0f, ScrollOffset-InputFontSize));
 			else if(CaretPositionY > ClippingRect.y+ClippingRect.h)

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -990,6 +990,10 @@ void CMenus::OnInit()
 
 	RenderLoading(1);
 
+	// setup browser address input
+	m_ServerAddressInput.SetBuffer(Config()->m_UiServerAddress, sizeof(Config()->m_UiServerAddress));
+	m_ServerAddressLanInput.SetBuffer(Config()->m_UiServerAddressLan, sizeof(Config()->m_UiServerAddressLan));
+
 	ServerBrowser()->SetType(Config()->m_UiBrowserPage == PAGE_LAN ? IServerBrowser::TYPE_LAN : IServerBrowser::TYPE_INTERNET);
 }
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -650,6 +650,8 @@ private:
 	int m_AddressSelection;
 	static CColumn ms_aBrowserCols[NUM_BROWSER_COLS];
 	static CColumn ms_aDemoCols[NUM_DEMO_COLS];
+	CLineInput m_ServerAddressInput;
+	CLineInput m_ServerAddressLanInput;
 
 	CBrowserFilter* GetSelectedBrowserFilter()
 	{

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1337,7 +1337,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		static CButtonContainer s_ClearButton;
 		if(DoButton_SpriteID(&s_ClearButton, IMAGE_TOOLICONS, SPRITE_TOOL_X_A, false, &Button, CUIRect::CORNER_ALL, 5.0f, true))
 		{
-			Config()->m_BrFilterString[0] = 0;
+			s_FilterInput.Clear();
 			UI()->SetActiveItem(&Config()->m_BrFilterString);
 			Client()->ServerBrowserUpdate();
 		}
@@ -1351,16 +1351,14 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 	if(BrowserType == IServerBrowser::TYPE_INTERNET)
 	{
-		static CLineInput s_AddressInput(Config()->m_UiServerAddress, sizeof(Config()->m_UiServerAddress));
-		if(UI()->DoEditBox(&s_AddressInput, &EditBox, FontSize))
+		if(UI()->DoEditBox(&m_ServerAddressInput, &EditBox, FontSize))
 		{
 			m_AddressSelection |= ADDR_SELECTION_CHANGE | ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND | ADDR_SELECTION_REVEAL;
 		}
 	}
 	else if(BrowserType == IServerBrowser::TYPE_LAN)
 	{
-		static CLineInput s_AddressInput(Config()->m_UiServerAddressLan, sizeof(Config()->m_UiServerAddressLan));
-		if(UI()->DoEditBox(&s_AddressInput, &EditBox, FontSize))
+		if(UI()->DoEditBox(&m_ServerAddressLanInput, &EditBox, FontSize))
 		{
 			m_AddressSelection |= ADDR_SELECTION_CHANGE | ADDR_SELECTION_RESET_SERVER_IF_NOT_FOUND | ADDR_SELECTION_REVEAL;
 		}
@@ -1680,8 +1678,8 @@ void CMenus::RenderServerbrowserFriendTab(CUIRect View)
 		m_pClient->Friends()->AddFriend(s_aName, s_aClan);
 		FriendlistOnUpdate();
 		Client()->ServerBrowserUpdate();
-		s_aName[0] = 0;
-		s_aClan[0] = 0;
+		s_NameInput.Clear();
+		s_ClanInput.Clear();
 	}
 
 	// delete friend
@@ -1727,7 +1725,7 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 		{
 			m_lFilters.add(CBrowserFilter(CBrowserFilter::FILTER_CUSTOM, s_aFilterName, ServerBrowser()));
 			m_lFilters[m_lFilters.size()-1].Switch();
-			s_aFilterName[0] = 0;
+			s_FilterInput.Clear();
 			Client()->ServerBrowserUpdate();
 		}
 	}
@@ -1892,7 +1890,7 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 					str_copy(FilterInfo.m_aGametype[i], s_aGametype, sizeof(FilterInfo.m_aGametype[i]));
 					FilterInfo.m_aGametypeExclusive[i] = false;
 					UpdateFilter = true;
-					s_aGametype[0] = 0;
+					s_GametypeInput.Clear();
 					break;
 				}
 			}
@@ -1909,7 +1907,7 @@ void CMenus::RenderServerbrowserFilterTab(CUIRect View)
 					str_copy(FilterInfo.m_aGametype[i], s_aGametype, sizeof(FilterInfo.m_aGametype[i]));
 					FilterInfo.m_aGametypeExclusive[i] = true;
 					UpdateFilter = true;
-					s_aGametype[0] = 0;
+					s_GametypeInput.Clear();
 					break;
 				}
 			}
@@ -2416,9 +2414,9 @@ void CMenus::SetServerBrowserAddress(const char *pAddress)
 {
 	const int Type = ServerBrowser()->GetType();
 	if(Type == IServerBrowser::TYPE_INTERNET)
-		str_copy(Config()->m_UiServerAddress, pAddress, sizeof(Config()->m_UiServerAddress));
+		m_ServerAddressInput.Set(pAddress);
 	else if(Type == IServerBrowser::TYPE_LAN)
-		str_copy(Config()->m_UiServerAddressLan, pAddress, sizeof(Config()->m_UiServerAddressLan));
+		m_ServerAddressLanInput.Set(pAddress);
 }
 
 void CMenus::ServerBrowserFilterOnUpdate()

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -751,6 +751,8 @@ void CMenus::RenderServerControl(CUIRect MainView)
 	Extended.Margin(Spacing, &Extended);
 	Extended.HSplitTop(LineHeight, &Bottom, &Extended);
 	{
+		static CLineInput s_ReasonInput(m_aCallvoteReason, sizeof(m_aCallvoteReason));
+	
 		if(Authed || m_pClient->m_aClients[m_pClient->m_LocalClientID].m_Team != TEAM_SPECTATORS)
 		{
 			CUIRect Search;
@@ -789,20 +791,19 @@ void CMenus::RenderServerControl(CUIRect MainView)
 				Reason.VSplitLeft(TextRender()->TextWidth(FontSize, pReasonLabel, -1) + 10.0f, &Label, &Reason);
 				Label.y += 2.0f;
 				UI()->DoLabel(&Label, pReasonLabel, FontSize, TEXTALIGN_LEFT);
-				static CLineInput s_ReasonInput(m_aCallvoteReason, sizeof(m_aCallvoteReason));
 				UI()->DoEditBox(&s_ReasonInput, &Reason, FontSize, false, CUIRect::CORNER_L);
 
 				// clear button
 				static CButtonContainer s_ClearButton;
 				if(DoButton_SpriteID(&s_ClearButton, IMAGE_TOOLICONS, SPRITE_TOOL_X_A, false, &ClearButton, CUIRect::CORNER_R, 5.0f, true))
-					m_aCallvoteReason[0] = 0;
+					s_ReasonInput.Clear();
 
 				// call vote button
 				static CButtonContainer s_CallVoteButton;
 				if(DoButton_Menu(&s_CallVoteButton, Localize("Call vote"), 0, &CallVoteButton) || DoCallVote)
 				{
 					HandleCallvote(s_ControlPage, false);
-					m_aCallvoteReason[0] = 0;
+					s_ReasonInput.Clear();
 				}
 			}
 		}
@@ -821,7 +822,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 			if(DoButton_Menu(&s_ForceVoteButton, Localize("Force vote"), 0, &Button))
 			{
 				HandleCallvote(s_ControlPage, true);
-				m_aCallvoteReason[0] = 0;
+				s_ReasonInput.Clear();
 			}
 
 			if(s_ControlPage == 0)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -17,6 +17,7 @@
 #include <generated/client_data.h>
 
 #include <game/version.h>
+#include "lineinput.h"
 #include "localization.h"
 #include "render.h"
 
@@ -612,6 +613,9 @@ void CGameClient::OnRender()
 
 	// clear all events/input for this frame
 	Input()->Clear();
+
+	// render ime candidates
+	CLineInput::RenderCandidates();
 }
 
 void CGameClient::OnRelease()

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -14,6 +14,9 @@ IGraphics *CLineInput::s_pGraphics = 0;
 CLineInput *CLineInput::s_apActiveInputs[MAX_ACTIVE_INPUTS] = { 0 };
 unsigned CLineInput::s_NumActiveInputs = 0;
 
+vec2 CLineInput::s_CompositionWindowPosition = vec2(0, 0);
+float CLineInput::s_CompositionLineHeight = 0.0f;
+
 void CLineInput::SetBuffer(char *pStr, int MaxSize, int MaxChars)
 {
 	if(m_pStr && m_pStr == pStr)
@@ -31,6 +34,58 @@ void CLineInput::SetBuffer(char *pStr, int MaxSize, int MaxChars)
 	{
 		UpdateStrData();
 	}
+}
+
+void CLineInput::DrawSelection(float HeightWeight, int Start, int End, vec4 Color)
+{
+	const int VAlign = m_TextCursor.m_Align&TEXTALIGN_MASK_VERT;
+
+	const vec2 StartPos = s_pTextRender->CaretPosition(&m_TextCursor, Start);
+	const vec2 EndPos = s_pTextRender->CaretPosition(&m_TextCursor, End);
+	const float LineHeight = m_TextCursor.BaseLineY()/m_TextCursor.LineCount();
+	const float VAlignOffset =
+		(VAlign == TEXTALIGN_TOP) ? -LineHeight*(1.0f-HeightWeight)-1.0f :
+		(VAlign == TEXTALIGN_MIDDLE) ? -LineHeight*(1.0f-HeightWeight)+LineHeight/2 :
+		/* TEXTALIGN_BOTTOM */ LineHeight*(1.35f-1.0f+HeightWeight)-1.0f;
+	s_pGraphics->TextureClear();
+	s_pGraphics->QuadsBegin();
+	s_pGraphics->SetColor(Color);
+	if(StartPos.y < EndPos.y) // multi line selection
+	{
+		CTextBoundingBox BoundingBox = m_TextCursor.BoundingBox();
+		int NumQuads = 0;
+		IGraphics::CQuadItem SelectionQuads[3];
+		SelectionQuads[NumQuads++] = IGraphics::CQuadItem(StartPos.x, StartPos.y - VAlignOffset, BoundingBox.Right() - StartPos.x, LineHeight*HeightWeight);
+		const float SecondSegmentY = StartPos.y - VAlignOffset + LineHeight;
+		if(EndPos.y - StartPos.y > LineHeight)
+		{
+			const float MiddleSegmentHeight = EndPos.y - StartPos.y - LineHeight;
+			SelectionQuads[NumQuads++] = IGraphics::CQuadItem(BoundingBox.x, SecondSegmentY, BoundingBox.w, MiddleSegmentHeight);
+			SelectionQuads[NumQuads++] = IGraphics::CQuadItem(BoundingBox.x, SecondSegmentY + MiddleSegmentHeight, EndPos.x - BoundingBox.x, LineHeight*HeightWeight);
+		}
+		else
+			SelectionQuads[NumQuads++] = IGraphics::CQuadItem(BoundingBox.x, SecondSegmentY, EndPos.x - BoundingBox.x, LineHeight*HeightWeight);
+		s_pGraphics->QuadsDrawTL(SelectionQuads, NumQuads);
+	}
+	else // single line selection
+	{
+		IGraphics::CQuadItem SelectionQuad = IGraphics::CQuadItem(StartPos.x, StartPos.y - VAlignOffset, EndPos.x - StartPos.x, LineHeight*HeightWeight);
+		s_pGraphics->QuadsDrawTL(&SelectionQuad, 1);
+	}
+	s_pGraphics->QuadsEnd();
+}
+
+void CLineInput::SetCompositionWindowPosition(vec2 Anchor, float LineHeight)
+{
+	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
+	int ScreenWidth = s_pGraphics->ScreenWidth();
+	int ScreenHeight = s_pGraphics->ScreenHeight();
+	s_pGraphics->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+
+	vec2 ScreenScale = vec2(ScreenWidth / (ScreenX1 - ScreenX0), ScreenHeight / (ScreenY1 - ScreenY0));
+	s_CompositionWindowPosition = Anchor * ScreenScale;
+	s_CompositionLineHeight = LineHeight * ScreenScale.y;
+	s_pInput->SetCompositionWindowPosition(s_CompositionWindowPosition.x, s_CompositionWindowPosition.y);
 }
 
 void CLineInput::Clear()
@@ -75,7 +130,6 @@ void CLineInput::SetRange(const char *pString, int Begin, int End)
 		m_pStr[m_Len] = '\0';
 		m_SelectionStart = m_SelectionEnd = m_CursorPos;
 	}
-	UpdateTextCursor(IsActive());
 }
 
 void CLineInput::UpdateStrData()
@@ -83,13 +137,6 @@ void CLineInput::UpdateStrData()
 	str_utf8_stats(m_pStr, m_MaxSize, &m_Len, &m_NumChars);
 	if(m_CursorPos < 0 || m_CursorPos > m_Len)
 		m_SelectionStart = m_SelectionEnd = m_CursorPos = m_Len;
-}
-
-void CLineInput::UpdateTextCursor(bool Active)
-{
-	m_TextCursor.Reset();
-	if (s_pTextRender && m_pStr)
-		s_pTextRender->TextDeferred(&m_TextCursor, m_pStr, -1);
 }
 
 bool CLineInput::MoveWordStop(char c)
@@ -292,49 +339,39 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 
 void CLineInput::Render()
 {
-	UpdateTextCursor(IsActive());
-	s_pTextRender->DrawTextOutlined(&m_TextCursor);
+	m_TextCursor.Reset();
+
+	if(!m_pStr)
+		return;
 
 	if(IsActive())
 	{
+		const int CompositionCursor = s_pInput->GetCompositionCursor();
+		const bool HasComposition = s_pInput->HasComposition();
+		const int CompositionStart = GetCursorOffset() + CompositionCursor;
+		const int CompositionEnd = CompositionStart + s_pInput->GetCompositionSelectedLength();
+
 		const int VAlign = m_TextCursor.m_Align&TEXTALIGN_MASK_VERT;
-		
-		// render selection
-		if(GetSelectionLength())
+
+		if(HasComposition)
 		{
-			const vec2 StartPos = s_pTextRender->CaretPosition(&m_TextCursor, GetSelectionStart());
-			const vec2 EndPos = s_pTextRender->CaretPosition(&m_TextCursor, GetSelectionEnd());
-			const float LineHeight = m_TextCursor.BaseLineY()/m_TextCursor.LineCount();
-			const float VAlignOffset =
-				(VAlign == TEXTALIGN_TOP) ? -1.0f :
-				(VAlign == TEXTALIGN_MIDDLE) ? LineHeight/2 :
-				/* TEXTALIGN_BOTTOM */ LineHeight + LineHeight * 0.35f - 1.0f;
-			s_pGraphics->TextureClear();
-			s_pGraphics->QuadsBegin();
-			s_pGraphics->SetColor(0.3f, 0.3f, 0.3f, 0.3f);
-			if(StartPos.y < EndPos.y) // multi line selection
-			{
-				CTextBoundingBox BoundingBox = m_TextCursor.BoundingBox();
-				int NumQuads = 0;
-				IGraphics::CQuadItem SelectionQuads[3];
-				SelectionQuads[NumQuads++] = IGraphics::CQuadItem(StartPos.x, StartPos.y - VAlignOffset, BoundingBox.Right() - StartPos.x, LineHeight);
-				const float SecondSegmentY = StartPos.y - VAlignOffset + LineHeight;
-				if(EndPos.y - StartPos.y > LineHeight)
-				{
-					const float MiddleSegmentHeight = EndPos.y - StartPos.y - LineHeight;
-					SelectionQuads[NumQuads++] = IGraphics::CQuadItem(BoundingBox.x, SecondSegmentY, BoundingBox.w, MiddleSegmentHeight);
-					SelectionQuads[NumQuads++] = IGraphics::CQuadItem(BoundingBox.x, SecondSegmentY + MiddleSegmentHeight, EndPos.x - BoundingBox.x, LineHeight);
-				}
-				else
-					SelectionQuads[NumQuads++] = IGraphics::CQuadItem(BoundingBox.x, SecondSegmentY, EndPos.x - BoundingBox.x, LineHeight);
-				s_pGraphics->QuadsDrawTL(SelectionQuads, NumQuads);
-			}
-			else // single line selection
-			{
-				IGraphics::CQuadItem SelectionQuad = IGraphics::CQuadItem(StartPos.x, StartPos.y - VAlignOffset, EndPos.x - StartPos.x, LineHeight);
-				s_pGraphics->QuadsDrawTL(&SelectionQuad, 1);
-			}
-			s_pGraphics->QuadsEnd();
+			s_pTextRender->TextDeferred(&m_TextCursor, m_pStr, GetCursorOffset());
+			s_pTextRender->TextDeferred(&m_TextCursor, s_pInput->GetComposition(), -1);
+			s_pTextRender->TextDeferred(&m_TextCursor, m_pStr + GetCursorOffset(), -1);
+			s_pTextRender->DrawTextOutlined(&m_TextCursor);
+			DrawSelection(0.1f, GetCursorOffset(), GetCursorOffset()+s_pInput->GetCompositionLength(), vec4(0.7f, 0.7f, 0.7f, 0.7f));
+		}
+		else
+		{
+			s_pTextRender->TextOutlined(&m_TextCursor, m_pStr, -1);
+		}
+
+		// render selection
+		if(GetSelectionLength() || HasComposition)
+		{
+			const int Start = HasComposition ? CompositionStart : GetSelectionStart();
+			const int End = HasComposition ? CompositionEnd : GetSelectionEnd();
+			DrawSelection(1.0f, Start, End, vec4(0.3f, 0.3f, 0.3f, 0.3f));
 		}
 
 		static CTextCursor s_MarkerCursor;
@@ -342,16 +379,97 @@ void CLineInput::Render()
 		s_MarkerCursor.Reset(s_MarkerCursor.m_FontSize);
 		s_MarkerCursor.m_Align = VAlign | TEXTALIGN_CENTER;
 		s_pTextRender->TextDeferred(&s_MarkerCursor, "｜", -1);
-		vec2 Offset = s_pTextRender->CaretPosition(&m_TextCursor, GetCursorOffset());
+		vec2 Offset = s_pTextRender->CaretPosition(&m_TextCursor, HasComposition ? CompositionStart : GetCursorOffset());
 		s_MarkerCursor.MoveTo(Offset);
-		CTextBoundingBox BoundingBox = s_MarkerCursor.BoundingBox();
-		s_pInput->SetTextCompositionWindowPosition(BoundingBox.Right(), BoundingBox.Bottom());
 
 		// render blinking caret
 		if((2*time_get()/time_freq())%2)
 		{
 			s_pTextRender->DrawTextOutlined(&s_MarkerCursor);
 		}
+
+		if(HasComposition)
+		{
+			vec2 CursorPosition = s_pTextRender->CaretPosition(&m_TextCursor, GetCursorOffset());
+			s_MarkerCursor.MoveTo(CursorPosition);
+			CTextBoundingBox BoundingBox = s_MarkerCursor.BoundingBox();
+			SetCompositionWindowPosition(vec2(BoundingBox.Right(), BoundingBox.Bottom()), BoundingBox.h);
+		}
+
+	}
+	else
+	{
+		s_pTextRender->TextOutlined(&m_TextCursor, m_pStr, -1);
+	}
+}
+
+void CLineInput::RenderCandidates()
+{
+	if(s_pInput->HasComposition() && s_pInput->GetCandidateCount() > 0)
+	{
+		const float FontSize = 7.0f;
+		const float Height = 300;
+		const float Width = Height*s_pGraphics->ScreenAspect();
+		int ScreenWidth = s_pGraphics->ScreenWidth();
+		int ScreenHeight = s_pGraphics->ScreenHeight();
+
+		s_pGraphics->MapScreen(0, 0, Width, Height);
+
+		static CTextCursor s_CandidateCursor;
+		s_CandidateCursor.Reset();
+		s_CandidateCursor.m_FontSize = FontSize;
+		s_CandidateCursor.m_LineSpacing = FontSize*0.35f;
+		s_CandidateCursor.m_MaxLines = -1;
+
+		vec2 Position = s_CompositionWindowPosition / vec2(ScreenWidth, ScreenHeight) * vec2(Width, Height);
+		float SelectedCandidateY = 0;
+		for(int i = 0; i < s_pInput->GetCandidateCount(); ++i)
+		{
+			char aBuf[32];
+
+			if(i == s_pInput->GetCandidateSelectedIndex())
+				SelectedCandidateY = s_CandidateCursor.Height();
+
+			if(i > 0)
+				s_pTextRender->TextNewline(&s_CandidateCursor);
+			
+			str_format(aBuf, 32, "%d. ", (i+1)%10);
+
+			s_pTextRender->TextColor(0.8f, 0.8f, 0.8f, 1.0f);
+			s_pTextRender->TextDeferred(&s_CandidateCursor, aBuf, -1);
+			s_pTextRender->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+			s_pTextRender->TextDeferred(&s_CandidateCursor, s_pInput->GetCandidate(i), -1);
+		}
+
+		CTextBoundingBox BoundingBox = s_CandidateCursor.BoundingBox();
+
+		// move candidate window up if needed
+		if(Position.y + FontSize * 13.5f > Height)
+			Position.y -= BoundingBox.h + s_CompositionLineHeight / ScreenHeight * Height;
+
+		// move candidate window left if needed
+		if(Position.x + BoundingBox.w + 2.0f > Width)
+			Position.x -= Position.x + BoundingBox.w + 2.0f - Width;
+
+		s_CandidateCursor.MoveTo(Position);
+		BoundingBox = s_CandidateCursor.BoundingBox();
+
+		// draw rect
+		s_pGraphics->TextureClear();
+		s_pGraphics->QuadsBegin();
+		s_pGraphics->BlendNormal();
+
+		s_pGraphics->SetColor(0.0f, 0.0f, 0.0f, 0.9f);
+		IGraphics::CQuadItem Quad = IGraphics::CQuadItem(BoundingBox.x-1, BoundingBox.y-1, BoundingBox.w+2, BoundingBox.h+2);
+		s_pGraphics->QuadsDrawTL(&Quad, 1);
+
+		s_pGraphics->SetColor(0.8f, 0.8f, 0.8f, 0.9f);
+		Quad = IGraphics::CQuadItem(BoundingBox.x, BoundingBox.y + SelectedCandidateY, BoundingBox.w, FontSize*1.35f);
+		s_pGraphics->QuadsDrawTL(&Quad, 1);
+		s_pGraphics->QuadsEnd();
+
+	
+		s_pTextRender->DrawTextOutlined(&s_CandidateCursor);
 	}
 }
 

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -34,6 +34,7 @@ void CLineInput::SetBuffer(char *pStr, int MaxSize, int MaxChars)
 	{
 		UpdateStrData();
 	}
+	m_TextVersion = 0;
 }
 
 void CLineInput::DrawSelection(float HeightWeight, int Start, int End, vec4 Color)
@@ -92,6 +93,7 @@ void CLineInput::Clear()
 {
 	mem_zero(m_pStr, m_MaxSize);
 	UpdateStrData();
+	m_TextVersion++;
 }
 
 void CLineInput::Set(const char *pString)
@@ -99,6 +101,7 @@ void CLineInput::Set(const char *pString)
 	str_copy(m_pStr, pString, m_MaxSize);
 	UpdateStrData();
 	SetCursorOffset(m_Len);
+	m_TextVersion++;
 }
 
 void CLineInput::SetRange(const char *pString, int Begin, int End)
@@ -130,6 +133,7 @@ void CLineInput::SetRange(const char *pString, int Begin, int End)
 		m_pStr[m_Len] = '\0';
 		m_SelectionStart = m_SelectionEnd = m_CursorPos;
 	}
+	m_TextVersion++;
 }
 
 void CLineInput::UpdateStrData()
@@ -334,13 +338,13 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 
 	m_WasChanged |= OldCursorPos != m_CursorPos;
 	m_WasChanged |= SelectionLength != GetSelectionLength();
+	m_TextVersion += m_WasChanged;
+
 	return m_WasChanged;
 }
 
 void CLineInput::Render()
 {
-	m_TextCursor.Reset();
-
 	if(!m_pStr)
 		return;
 
@@ -355,6 +359,7 @@ void CLineInput::Render()
 
 		if(HasComposition)
 		{
+			m_TextCursor.Reset(-1); // composition is dynamic
 			s_pTextRender->TextDeferred(&m_TextCursor, m_pStr, GetCursorOffset());
 			s_pTextRender->TextDeferred(&m_TextCursor, s_pInput->GetComposition(), -1);
 			s_pTextRender->TextDeferred(&m_TextCursor, m_pStr + GetCursorOffset(), -1);
@@ -363,6 +368,7 @@ void CLineInput::Render()
 		}
 		else
 		{
+			m_TextCursor.Reset(m_TextVersion);
 			s_pTextRender->TextOutlined(&m_TextCursor, m_pStr, -1);
 		}
 
@@ -395,6 +401,7 @@ void CLineInput::Render()
 	}
 	else
 	{
+		m_TextCursor.Reset(m_TextVersion);
 		s_pTextRender->TextOutlined(&m_TextCursor, m_pStr, -1);
 	}
 }

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -85,7 +85,7 @@ void CLineInput::SetCompositionWindowPosition(vec2 Anchor, float LineHeight)
 	vec2 ScreenScale = vec2(ScreenWidth / (ScreenX1 - ScreenX0), ScreenHeight / (ScreenY1 - ScreenY0));
 	s_CompositionWindowPosition = Anchor * ScreenScale;
 	s_CompositionLineHeight = LineHeight * ScreenScale.y;
-	s_pInput->SetCompositionWindowPosition(s_CompositionWindowPosition.x, s_CompositionWindowPosition.y);
+	s_pInput->SetCompositionWindowPosition(s_CompositionWindowPosition.x, s_CompositionWindowPosition.y - s_CompositionLineHeight, s_CompositionLineHeight);
 }
 
 void CLineInput::Clear()
@@ -388,14 +388,10 @@ void CLineInput::Render()
 			s_pTextRender->DrawTextOutlined(&s_MarkerCursor);
 		}
 
-		if(HasComposition)
-		{
-			vec2 CursorPosition = s_pTextRender->CaretPosition(&m_TextCursor, GetCursorOffset());
-			s_MarkerCursor.MoveTo(CursorPosition);
-			CTextBoundingBox BoundingBox = s_MarkerCursor.BoundingBox();
-			SetCompositionWindowPosition(vec2(BoundingBox.Right(), BoundingBox.Bottom()), BoundingBox.h);
-		}
-
+		vec2 CursorPosition = s_pTextRender->CaretPosition(&m_TextCursor, GetCursorOffset());
+		s_MarkerCursor.MoveTo(CursorPosition);
+		CTextBoundingBox BoundingBox = s_MarkerCursor.BoundingBox();
+		SetCompositionWindowPosition(vec2(BoundingBox.Right(), BoundingBox.Bottom()), BoundingBox.h);
 	}
 	else
 	{
@@ -408,6 +404,8 @@ void CLineInput::RenderCandidates()
 	if(s_pInput->HasComposition() && s_pInput->GetCandidateCount() > 0)
 	{
 		const float FontSize = 7.0f;
+		const float HMargin = 8.0f;
+		const float VMargin = 4.0f;
 		const float Height = 300;
 		const float Width = Height*s_pGraphics->ScreenAspect();
 		int ScreenWidth = s_pGraphics->ScreenWidth();
@@ -435,40 +433,48 @@ void CLineInput::RenderCandidates()
 			
 			str_format(aBuf, 32, "%d. ", (i+1)%10);
 
-			s_pTextRender->TextColor(0.8f, 0.8f, 0.8f, 1.0f);
+			s_pTextRender->TextColor(0.6f, 0.6f, 0.6f, 1.0f);
 			s_pTextRender->TextDeferred(&s_CandidateCursor, aBuf, -1);
 			s_pTextRender->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 			s_pTextRender->TextDeferred(&s_CandidateCursor, s_pInput->GetCandidate(i), -1);
 		}
 
 		CTextBoundingBox BoundingBox = s_CandidateCursor.BoundingBox();
+		BoundingBox.x = Position.x;
+		BoundingBox.y = Position.y;
+		BoundingBox.w += HMargin;
+		BoundingBox.h += VMargin;
 
 		// move candidate window up if needed
-		if(Position.y + FontSize * 13.5f > Height)
-			Position.y -= BoundingBox.h + s_CompositionLineHeight / ScreenHeight * Height;
+		if(BoundingBox.y + FontSize * 13.5f > Height)
+			BoundingBox.y -= BoundingBox.h + s_CompositionLineHeight / ScreenHeight * Height;
 
 		// move candidate window left if needed
-		if(Position.x + BoundingBox.w + 2.0f > Width)
-			Position.x -= Position.x + BoundingBox.w + 2.0f - Width;
+		if(BoundingBox.x + BoundingBox.w + HMargin > Width)
+			BoundingBox.x -= BoundingBox.x + BoundingBox.w + HMargin - Width;
 
-		s_CandidateCursor.MoveTo(Position);
-		BoundingBox = s_CandidateCursor.BoundingBox();
+		s_CandidateCursor.MoveTo(vec2(BoundingBox.x+HMargin/2, BoundingBox.y+VMargin/2));
 
-		// draw rect
 		s_pGraphics->TextureClear();
 		s_pGraphics->QuadsBegin();
 		s_pGraphics->BlendNormal();
 
-		s_pGraphics->SetColor(0.0f, 0.0f, 0.0f, 0.9f);
-		IGraphics::CQuadItem Quad = IGraphics::CQuadItem(BoundingBox.x-1, BoundingBox.y-1, BoundingBox.w+2, BoundingBox.h+2);
+		// window shadow
+		s_pGraphics->SetColor(0.0f, 0.0f, 0.0f, 0.8f);
+		IGraphics::CQuadItem Quad = IGraphics::CQuadItem(BoundingBox.x+0.75f, BoundingBox.y+0.75f, BoundingBox.w, BoundingBox.h);
 		s_pGraphics->QuadsDrawTL(&Quad, 1);
 
-		s_pGraphics->SetColor(0.8f, 0.8f, 0.8f, 0.9f);
-		Quad = IGraphics::CQuadItem(BoundingBox.x, BoundingBox.y + SelectedCandidateY, BoundingBox.w, FontSize*1.35f);
+		// window background
+		s_pGraphics->SetColor(0.15f, 0.15f, 0.15f, 1.0f);
+		Quad = IGraphics::CQuadItem(BoundingBox.x, BoundingBox.y, BoundingBox.w, BoundingBox.h);
+		s_pGraphics->QuadsDrawTL(&Quad, 1);
+
+		// highlight
+		s_pGraphics->SetColor(0.1f, 0.4f, 0.8f, 1.0f);
+		Quad = IGraphics::CQuadItem(BoundingBox.x+HMargin/4, BoundingBox.y+VMargin/2+SelectedCandidateY, BoundingBox.w-HMargin/2, FontSize*1.35f);
 		s_pGraphics->QuadsDrawTL(&Quad, 1);
 		s_pGraphics->QuadsEnd();
 
-	
 		s_pTextRender->DrawTextOutlined(&s_CandidateCursor);
 	}
 }

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -289,7 +289,7 @@ void CLineInput::Render(CTextCursor *pCursor)
 	if(IsActive())
 	{
 		const int VAlign = pCursor->m_Align&TEXTALIGN_MASK_VERT;
-
+		
 		// render selection
 		if(GetSelectionLength())
 		{
@@ -327,6 +327,8 @@ void CLineInput::Render(CTextCursor *pCursor)
 			}
 			s_pGraphics->QuadsEnd();
 		}
+
+		// render on the spot composition
 
 		// render blinking caret
 		if((2*time_get()/time_freq())%2)
@@ -389,8 +391,10 @@ void CLineInput::SetActive(bool Active)
 
 void CLineInput::OnActivate()
 {
+	s_pInput->StartTextInput();
 }
 
 void CLineInput::OnDeactivate()
 {
+	s_pInput->StopTextInput();
 }

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -75,6 +75,7 @@ void CLineInput::SetRange(const char *pString, int Begin, int End)
 		m_pStr[m_Len] = '\0';
 		m_SelectionStart = m_SelectionEnd = m_CursorPos;
 	}
+	UpdateTextCursor(IsActive());
 }
 
 void CLineInput::UpdateStrData()
@@ -82,6 +83,13 @@ void CLineInput::UpdateStrData()
 	str_utf8_stats(m_pStr, m_MaxSize, &m_Len, &m_NumChars);
 	if(m_CursorPos < 0 || m_CursorPos > m_Len)
 		m_SelectionStart = m_SelectionEnd = m_CursorPos = m_Len;
+}
+
+void CLineInput::UpdateTextCursor(bool Active)
+{
+	m_TextCursor.Reset();
+	if (s_pTextRender && m_pStr)
+		s_pTextRender->TextDeferred(&m_TextCursor, m_pStr, -1);
 }
 
 bool CLineInput::MoveWordStop(char c)
@@ -282,30 +290,31 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 	return m_WasChanged;
 }
 
-void CLineInput::Render(CTextCursor *pCursor)
+void CLineInput::Render()
 {
-	s_pTextRender->DrawTextOutlined(pCursor);
+	UpdateTextCursor(IsActive());
+	s_pTextRender->DrawTextOutlined(&m_TextCursor);
 
 	if(IsActive())
 	{
-		const int VAlign = pCursor->m_Align&TEXTALIGN_MASK_VERT;
+		const int VAlign = m_TextCursor.m_Align&TEXTALIGN_MASK_VERT;
 		
 		// render selection
 		if(GetSelectionLength())
 		{
-			const vec2 StartPos = s_pTextRender->CaretPosition(pCursor, GetSelectionStart());
-			const vec2 EndPos = s_pTextRender->CaretPosition(pCursor, GetSelectionEnd());
-			const float LineHeight = pCursor->BaseLineY()/pCursor->LineCount();
+			const vec2 StartPos = s_pTextRender->CaretPosition(&m_TextCursor, GetSelectionStart());
+			const vec2 EndPos = s_pTextRender->CaretPosition(&m_TextCursor, GetSelectionEnd());
+			const float LineHeight = m_TextCursor.BaseLineY()/m_TextCursor.LineCount();
 			const float VAlignOffset =
 				(VAlign == TEXTALIGN_TOP) ? -1.0f :
 				(VAlign == TEXTALIGN_MIDDLE) ? LineHeight/2 :
-				/* TEXTALIGN_BOTTOM */ LineHeight - 1.0f;
+				/* TEXTALIGN_BOTTOM */ LineHeight + LineHeight * 0.35f - 1.0f;
 			s_pGraphics->TextureClear();
 			s_pGraphics->QuadsBegin();
 			s_pGraphics->SetColor(0.3f, 0.3f, 0.3f, 0.3f);
 			if(StartPos.y < EndPos.y) // multi line selection
 			{
-				CTextBoundingBox BoundingBox = pCursor->BoundingBox();
+				CTextBoundingBox BoundingBox = m_TextCursor.BoundingBox();
 				int NumQuads = 0;
 				IGraphics::CQuadItem SelectionQuads[3];
 				SelectionQuads[NumQuads++] = IGraphics::CQuadItem(StartPos.x, StartPos.y - VAlignOffset, BoundingBox.Right() - StartPos.x, LineHeight);
@@ -328,17 +337,19 @@ void CLineInput::Render(CTextCursor *pCursor)
 			s_pGraphics->QuadsEnd();
 		}
 
-		// render on the spot composition
+		static CTextCursor s_MarkerCursor;
+		s_MarkerCursor.m_FontSize = m_TextCursor.m_FontSize;
+		s_MarkerCursor.Reset(s_MarkerCursor.m_FontSize);
+		s_MarkerCursor.m_Align = VAlign | TEXTALIGN_CENTER;
+		s_pTextRender->TextDeferred(&s_MarkerCursor, "｜", -1);
+		vec2 Offset = s_pTextRender->CaretPosition(&m_TextCursor, GetCursorOffset());
+		s_MarkerCursor.MoveTo(Offset);
+		CTextBoundingBox BoundingBox = s_MarkerCursor.BoundingBox();
+		s_pInput->SetTextCompositionWindowPosition(BoundingBox.Right(), BoundingBox.Bottom());
 
 		// render blinking caret
 		if((2*time_get()/time_freq())%2)
 		{
-			static CTextCursor s_MarkerCursor;
-			s_MarkerCursor.Reset();
-			s_MarkerCursor.m_FontSize = pCursor->m_FontSize;
-			s_MarkerCursor.m_Align = VAlign | TEXTALIGN_CENTER;
-			s_pTextRender->TextDeferred(&s_MarkerCursor, "｜", -1);
-			s_MarkerCursor.MoveTo(s_pTextRender->CaretPosition(pCursor, GetCursorOffset()));
 			s_pTextRender->DrawTextOutlined(&s_MarkerCursor);
 		}
 	}

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -19,6 +19,9 @@ class CLineInput
 	static CLineInput *s_apActiveInputs[MAX_ACTIVE_INPUTS];
 	static unsigned s_NumActiveInputs;
 
+	static vec2 s_CompositionWindowPosition;
+	static float s_CompositionLineHeight;
+
 	class CTextCursor m_TextCursor;
 	char *m_pStr;
 	int m_MaxSize;
@@ -35,14 +38,16 @@ class CLineInput
 	bool m_WasChanged;
 
 	void UpdateStrData();
-	void UpdateTextCursor(bool Active);
 	static bool MoveWordStop(char c);
+	void DrawSelection(float HeightWeight, int Start, int End, vec4 Color);
 
 	void OnActivate();
 	void OnDeactivate();
 
 public:
 	static void Init(class IInput *pInput, class ITextRender *pTextRender, class IGraphics *pGraphics) { s_pInput = pInput; s_pTextRender = pTextRender; s_pGraphics = pGraphics; }
+	static void RenderCandidates();
+	static void SetCompositionWindowPosition(vec2 Anchor, float LineHeight);
 
 	static CLineInput *GetActiveInput() { return s_NumActiveInputs ? s_apActiveInputs[s_NumActiveInputs-1] : 0; }
 

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -23,6 +23,8 @@ class CLineInput
 	static float s_CompositionLineHeight;
 
 	class CTextCursor m_TextCursor;
+	unsigned int m_TextVersion;
+
 	char *m_pStr;
 	int m_MaxSize;
 	int m_MaxChars;

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -19,6 +19,7 @@ class CLineInput
 	static CLineInput *s_apActiveInputs[MAX_ACTIVE_INPUTS];
 	static unsigned s_NumActiveInputs;
 
+	class CTextCursor m_TextCursor;
 	char *m_pStr;
 	int m_MaxSize;
 	int m_MaxChars;
@@ -34,6 +35,7 @@ class CLineInput
 	bool m_WasChanged;
 
 	void UpdateStrData();
+	void UpdateTextCursor(bool Active);
 	static bool MoveWordStop(char c);
 
 	void OnActivate();
@@ -56,6 +58,7 @@ public:
 	void SetRange(const char *pString, int Begin, int End);
 	void Append(const char *pString) { SetRange(pString, m_CursorPos, m_CursorPos); }
 
+	class CTextCursor *GetCursor() { return &m_TextCursor; }
 	const char *GetString() const { return m_pStr; }
 	int GetMaxSize() const { return m_MaxSize; }
 	int GetMaxChars() const { return m_MaxChars; }
@@ -76,7 +79,7 @@ public:
 	bool ProcessInput(const IInput::CEvent &Event);
 	bool WasChanged() { bool Changed = m_WasChanged; m_WasChanged = false; return Changed; }
 
-	void Render(class CTextCursor *pCursor);
+	void Render();
 	bool IsActive() const { return GetActiveInput() == this; }
 	void SetActive(bool Active);
 };

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -345,6 +345,10 @@ void CUI::DoLabelSelected(const CUIRect *pRect, const char *pText, bool Selected
 
 bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, bool Hidden, int Corners, const IButtonColorFunction *pColorFunction)
 {
+	CTextCursor *pCursor = pLineInput->GetCursor();
+	pCursor->m_FontSize = FontSize;
+	pCursor->m_Align = TEXTALIGN_ML;
+
 	const bool Inside = MouseHovered(pRect);
 	const bool Active = LastActiveItem() == pLineInput;
 	const bool Changed = pLineInput->WasChanged();
@@ -498,13 +502,8 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 	pRect->Draw(pColorFunction->GetColor(Active, Inside), 5.0f, Corners);
 	ClipEnable(pRect);
 	Textbox.x -= ScrollOffset;
-	static CTextCursor s_TextCursor;
-	s_TextCursor.Reset();
-	s_TextCursor.m_FontSize = FontSize;
-	s_TextCursor.m_Align = TEXTALIGN_ML;
-	s_TextCursor.MoveTo(Textbox.x, Textbox.y + Textbox.h/2.0f);
-	TextRender()->TextDeferred(&s_TextCursor, pDisplayStr, -1);
-	pLineInput->Render(&s_TextCursor);
+	pCursor->MoveTo(Textbox.x, Textbox.y + Textbox.h/2.0f);
+	pLineInput->Render();
 	ClipDisable();
 
 	return Changed;


### PR DESCRIPTION
Since I can type Chinese and a little bit Japanese, I thought I should just do it and check in with you to get some feedback.

I moved the TextCursor into CLineInput, so we can render composition text into the Cursor, then the text is rendered when `CLineInput::Render()` is called.

In Windows, the candidate window is drawn in-game.
In MacOS, the composition window position scales according to `Config()->m_gfxScreenWidth` which is different from `Graphics()->ScreenWidth()` under HiDPI settings. Ideally this should be swapped out with a HiDPI scaling value which is avaliable in another PR https://github.com/teeworlds/teeworlds/pull/2827

demo video:
Windows: https://streamable.com/7o4z66
MacOS: https://streamable.com/r3un7s